### PR TITLE
Add ingress needs annotation rule

### DIFF
--- a/engine/types.go
+++ b/engine/types.go
@@ -56,6 +56,12 @@ var (
 			return cs.BatchV2alpha1().RESTClient()
 		},
 	}
+	WantIngress = Want{
+		"ingresses", &extv1b1.Ingress{},
+		func(cs *kubernetes.Clientset) rest.Interface {
+			return cs.ExtensionsV1beta1().RESTClient()
+		},
+	}
 )
 
 type RuleHandlerContext struct {

--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func main() {
 	engine.AddRule(rules.ScrapeNeedsPortsRule)
 	engine.AddRule(rules.ValidIAMRoleRule)
 	engine.AddRule(rules.RequireCronJobHistoryLimits)
+	engine.AddRule(rules.IngressNeedsAnnotation)
 
 	engine.AddOutput(alerts.NewSlackOutput(opts.slackToken))
 	engine.AddOutput(alerts.NewSNSOutput(opts.awsRegion))

--- a/rules/ingress_alerts.go
+++ b/rules/ingress_alerts.go
@@ -1,0 +1,32 @@
+package rules
+
+import (
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/uswitch/klint/engine"
+	extv1b1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	prefix = "com.uswitch.heimdall"
+)
+
+var IngressNeedsAnnotation = engine.NewRule(
+	func(old runtime.Object, new runtime.Object, ctx *engine.RuleHandlerContext) {
+		ingress := new.(*extv1b1.Ingress)
+		logger := log.WithFields(log.Fields{"name": ingress.Name, "namespace": ingress.Namespace, "rule": "IngressNeedsAnnotation"})
+		annotation := ingress.GetAnnotations()
+		hasAnnotation := false
+		for key := range annotation {
+			if strings.HasPrefix(key, prefix) {
+				logger.Debugf("Checking annotation %s", key)
+				hasAnnotation = true
+				break
+			}
+		}
+		if !hasAnnotation {
+			ctx.Alertf(new, "You don't have any alerts set up for your ingress: %s.%s. You may want to check https://github.com/uswitch/heimdall for more info.", ingress.Namespace, ingress.Name)
+		}
+	}, engine.WantIngress)


### PR DESCRIPTION
## What
This rule will check if ingress has an annotaion that matches 'com.uswitch.heimdall' name and if not it will send notification.

## How to test

In repo dir run 

```
go build .
./klint --kubeconfig="${HOME}"/.kube/config --slack-token=foo --age-limit=0 --debug
```

and check if `klint` tries to send messages to slack. also there should be nice debug message. 