### PR TITLE
Fix CronJob API version compatibility issue

### DIFF
--- a/engine/types.go
+++ b/engine/types.go
@@ -54,7 +54,7 @@ var (
 	WantCronJobs = Want{
 		"cronjobs", &batchv1.CronJob{},
 		func(cs *kubernetes.Clientset) rest.Interface {
-			return cs.BatchV1beta1().RESTClient()
+			return cs.BatchV1().RESTClient()
 		},
 	}
 	WantIngress = Want{

--- a/engine/types.go
+++ b/engine/types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Previously, `klint` was checking for CronJob resources using the deprecated `batch/v1beta1` API version. This caused an issue when running on Kubernetes clusters version 1.21 and later, where the CronJob resource has been moved to the `batch/v1` API group.

The error we were encountering:

```bash
Failed to watch *v1beta1.CronJob: failed to list *v1beta1.CronJob: the server could not find the requested resource
```

This PR updates the code to use the correct `batch/v1` API group for CronJob resources
