### PR TITLE
Migrated from fork: Differentiate between OOMKill and exceeding termination grace period

### DIFF
--- a/rules/cronjob_history.go
+++ b/rules/cronjob_history.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/uswitch/klint/engine"
 
-	batchv1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/rules/unsuccessful_exit.go
+++ b/rules/unsuccessful_exit.go
@@ -27,7 +27,11 @@ var UnsuccessfulExitRule = engine.NewRule(
 				case 143: // JVM SIGTERM
 					break
 				case 137: // Process got SIGKILLd
-					ctx.Alertf(newObj, "Pod `%s.%s` (container: `%s`) was killed by a SIGKILL. Please make sure you gracefully shut down in time or extend `terminationGracePeriodSeconds` on your pod.", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, c.Name)
+					if c.State.Terminated.Reason == "OOMKilled" {
+						ctx.Alertf(newObj, "Pod `%s.%s` (container: `%s`) ran out of memory and was killed.", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, c.Name)
+					} else {
+						ctx.Alertf(newObj, "Pod `%s.%s` (container: `%s`) was killed by a SIGKILL. Please make sure you gracefully shut down in time or extend `terminationGracePeriodSeconds` on your pod.", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, c.Name)
+					}
 				default:
 					tailLines := int64(20)
 					opts := &v1.PodLogOptions{


### PR DESCRIPTION
Message from fork PR:

> When cleaning up our alerts in Slack, we noticed that Klint was wrongly suggesting adding graceful termination, when in fact the reason for the termination was out-of-memory.

> This PR makes Klint's messages distinguish an OOMKill from a failed SIGTERM.